### PR TITLE
Use type_alias_enum_variants when running on nightly

### DIFF
--- a/examples/calculator/Cargo.toml
+++ b/examples/calculator/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Tim Süberkrüb <dev@timsueberkrueb.io>"]
 edition = "2018"
 
+[build-dependencies]
+# TODO: Remove once type_alias_enum_variants (RFC 2338) gets stabilized
+rustc_version = "0.2.3"
+
 [dependencies]
 yalr = { path = "../../yalr", features = ["logos"] }
 logos = "0.10.0-rc1"

--- a/examples/calculator/build.rs
+++ b/examples/calculator/build.rs
@@ -1,0 +1,8 @@
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    // TODO: Remove once type_alias_enum_variants (RFC 2338) gets stabilized
+    if let Channel::Nightly = version_meta().unwrap().channel {
+        println!("cargo:rustc-cfg=type_alias_enum_variants");
+    }
+}

--- a/examples/json/Cargo.toml
+++ b/examples/json/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Daniel Bicek dev@bicek.de"]
 edition = "2018"
 
+[build-dependencies]
+# TODO: Remove once type_alias_enum_variants (RFC 2338) gets stabilized
+rustc_version = "0.2.3"
+
 [dependencies]
 yalr = { path = "../../yalr", features = ["logos"] }
 logos = "0.10.0-rc1"

--- a/examples/json/build.rs
+++ b/examples/json/build.rs
@@ -1,0 +1,8 @@
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    // TODO: Remove once type_alias_enum_variants (RFC 2338) gets stabilized
+    if let Channel::Nightly = version_meta().unwrap().channel {
+        println!("cargo:rustc-cfg=type_alias_enum_variants");
+    }
+}

--- a/yalr_codegen/Cargo.toml
+++ b/yalr_codegen/Cargo.toml
@@ -3,6 +3,11 @@ name = "yalr_codegen"
 version = "0.1.0"
 authors = ["Tim Süberkrüb <dev@timsueberkrueb.io>"]
 edition = "2018"
+build = "build.rs"
+
+[build-dependencies]
+# TODO: Remove once type_alias_enum_variants (RFC 2338) gets stabilized
+rustc_version = "0.2.3"
 
 [dependencies]
 regex = "1"

--- a/yalr_codegen/build.rs
+++ b/yalr_codegen/build.rs
@@ -1,0 +1,9 @@
+// TODO: Remove once type_alias_enum_variants (RFC 2338) gets stabilized
+
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    if let Channel::Nightly = version_meta().unwrap().channel {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}


### PR DESCRIPTION
Once stabilized, this will make `codegen` less ugly. Note that this is only enabled on nightly to keep the project working on stable.